### PR TITLE
Add functionality construct to CML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ plugin.xml_gen
 .gradle/
 build/
 
+# MacOS
+.DS_Store

--- a/org.contextmapper.dsl/src/org/contextmapper/dsl/ContextMappingDSL.xtext
+++ b/org.contextmapper.dsl/src/org/contextmapper/dsl/ContextMappingDSL.xtext
@@ -202,8 +202,20 @@ Application:
 		((commands+=CommandEvent)* &
 		(events+=DomainEvent)* &
 		(services+=Service)* &
-		(flows+=Flow)*)
+		(flows+=Flow)* &
+		(functionalities+=Functionality)*)
 CLOSE)?
+;
+
+Functionality:
+	"Functionality" name=ID (OPEN
+		(sagaOrchestrator?="sagaOrchestrator")?
+		(functionalitySteps+=FunctionalityStep)*
+	CLOSE)?
+;
+
+FunctionalityStep:
+	boundedContext=[BoundedContext] '.' service=[tacticdsl::Service] '.' operation=[tacticdsl::ServiceOperation]
 ;
 
 Flow:

--- a/org.contextmapper.dsl/src/org/contextmapper/dsl/GenerateContextMappingDSL.mwe2
+++ b/org.contextmapper.dsl/src/org/contextmapper/dsl/GenerateContextMappingDSL.mwe2
@@ -132,6 +132,7 @@ Workflow {
 			validator = {
 				composedCheck = "org.contextmapper.dsl.validation.BoundedContextSemanticsValidator"
 				composedCheck = "org.contextmapper.dsl.validation.ApplicationFlowSemanticsValidator"
+				composedCheck = "org.contextmapper.dsl.validation.ApplicationFunctionalitySemanticsValidator"
 				composedCheck = "org.contextmapper.dsl.validation.BoundedContextRelationshipSemanticsValidator"
 				composedCheck = "org.contextmapper.dsl.validation.ContextMapSemanticsValidator"
 				composedCheck = "org.contextmapper.dsl.validation.AggregateSemanticsValidator"

--- a/org.contextmapper.dsl/src/org/contextmapper/dsl/validation/ApplicationFunctionalitySemanticsValidator.java
+++ b/org.contextmapper.dsl/src/org/contextmapper/dsl/validation/ApplicationFunctionalitySemanticsValidator.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2019 The Context Mapper Project Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.contextmapper.dsl.validation;
+
+import static org.contextmapper.dsl.validation.ValidationMessages.FUNCTIONALITY_STEP_CONTEXT_NOT_ON_MAP;
+import static org.contextmapper.dsl.validation.ValidationMessages.FUNCTIONALITY_STEP_SERVICE_NOT_ON_STEP_CONTEXT;
+import static org.contextmapper.dsl.validation.ValidationMessages.FUNCTIONALITY_STEP_OPERATION_NOT_ON_STEP_SERVICE;
+import static org.contextmapper.dsl.validation.ValidationMessages.FUNCTIONALITY_STEP_SERVICE_NOT_APPLICATION_SERVICE;
+
+import org.contextmapper.dsl.cml.CMLModelObjectsResolvingHelper;
+import org.contextmapper.dsl.contextMappingDSL.Application;
+import org.contextmapper.dsl.contextMappingDSL.BoundedContext;
+import org.contextmapper.dsl.contextMappingDSL.ContextMap;
+import org.contextmapper.dsl.contextMappingDSL.ContextMappingDSLPackage;
+import org.contextmapper.dsl.contextMappingDSL.ContextMappingModel;
+import org.contextmapper.dsl.contextMappingDSL.FunctionalityStep;
+import org.contextmapper.tactic.dsl.tacticdsl.Service;
+import org.contextmapper.tactic.dsl.tacticdsl.ServiceOperation;
+import org.eclipse.xtext.EcoreUtil2;
+import org.eclipse.xtext.validation.AbstractDeclarativeValidator;
+import org.eclipse.xtext.validation.Check;
+import org.eclipse.xtext.validation.EValidatorRegistrar;
+
+public class ApplicationFunctionalitySemanticsValidator extends AbstractDeclarativeValidator {
+
+	@Override
+	public void register(EValidatorRegistrar registrar) {
+		// not needed for classes used as ComposedCheck
+	}
+
+	@Check
+	public void contextInStepIsPartOfMap(final FunctionalityStep functionalityStep) {
+		CMLModelObjectsResolvingHelper helper = new CMLModelObjectsResolvingHelper((ContextMappingModel) EcoreUtil2.getRootContainer(functionalityStep));
+		
+		ContextMap map = helper.getContextMap(helper.resolveBoundedContext(functionalityStep));
+		BoundedContext stepContext = functionalityStep.getBoundedContext();
+		if (map == null || stepContext == null || !map.getBoundedContexts().contains(stepContext)) {
+			error(String.format(FUNCTIONALITY_STEP_CONTEXT_NOT_ON_MAP, stepContext.getName()), 
+					functionalityStep, ContextMappingDSLPackage.Literals.FUNCTIONALITY_STEP__BOUNDED_CONTEXT);
+		}
+	}
+
+	@Check
+	public void serviceInStepIsPartOfStepContext(final FunctionalityStep functionalityStep) {
+		CMLModelObjectsResolvingHelper helper = new CMLModelObjectsResolvingHelper((ContextMappingModel) EcoreUtil2.getRootContainer(functionalityStep));
+
+		BoundedContext stepContext = functionalityStep.getBoundedContext();
+		Service stepService = functionalityStep.getService();
+		if (stepContext == null || stepService == null) {
+			return;
+		}
+		
+		BoundedContext stepServiceContext = helper.resolveBoundedContext(stepService);
+		if (stepServiceContext == null || !stepContext.getName().equals(stepServiceContext.getName())) {
+			error(String.format(FUNCTIONALITY_STEP_SERVICE_NOT_ON_STEP_CONTEXT, stepService.getName(), stepContext.getName()), 
+					functionalityStep, ContextMappingDSLPackage.Literals.FUNCTIONALITY_STEP__SERVICE);
+		}
+	}
+	
+	@Check
+	public void serviceOperationInStepIsPartOfStepService(final FunctionalityStep functionalityStep) {
+		Service stepService = functionalityStep.getService();
+		ServiceOperation stepOperation = functionalityStep.getOperation();
+		if (stepService == null || stepOperation == null) {
+			return;
+		}
+		
+		Service stepOperationService = (Service) stepOperation.eContainer();
+		if (stepOperationService == null || !stepService.getName().equals(stepOperationService.getName())) {
+			error(String.format(FUNCTIONALITY_STEP_OPERATION_NOT_ON_STEP_SERVICE, stepOperation.getName(), stepService.getName()), 
+					functionalityStep, ContextMappingDSLPackage.Literals.FUNCTIONALITY_STEP__OPERATION);
+		}
+	}
+	
+	@Check
+	public void serviceInStepIsApplicationService(final FunctionalityStep functionalityStep) {
+		Service stepService = functionalityStep.getService();
+		if (stepService.eContainer() == null || !(stepService.eContainer() instanceof Application)) {
+			error(String.format(FUNCTIONALITY_STEP_SERVICE_NOT_APPLICATION_SERVICE, stepService.getName()), 
+					functionalityStep, ContextMappingDSLPackage.Literals.FUNCTIONALITY_STEP__SERVICE);
+		}
+	}
+}

--- a/org.contextmapper.dsl/src/org/contextmapper/dsl/validation/UniquenessValidator.java
+++ b/org.contextmapper.dsl/src/org/contextmapper/dsl/validation/UniquenessValidator.java
@@ -25,6 +25,7 @@ import static org.contextmapper.dsl.validation.ValidationMessages.SUBDOMAIN_OBJE
 import static org.contextmapper.dsl.validation.ValidationMessages.USE_CASE_NAME_NOT_UNIQUE;
 import static org.contextmapper.dsl.validation.ValidationMessages.DOMAIN_NOT_UNIQUE;
 import static org.contextmapper.dsl.validation.ValidationMessages.FLOW_NAME_NOT_UNIQUE;
+import static org.contextmapper.dsl.validation.ValidationMessages.FUNCTIONALITY_NAME_NOT_UNIQUE;
 
 import java.util.HashSet;
 import java.util.Iterator;
@@ -38,6 +39,7 @@ import org.contextmapper.dsl.contextMappingDSL.BoundedContext;
 import org.contextmapper.dsl.contextMappingDSL.ContextMappingDSLPackage;
 import org.contextmapper.dsl.contextMappingDSL.Domain;
 import org.contextmapper.dsl.contextMappingDSL.Flow;
+import org.contextmapper.dsl.contextMappingDSL.Functionality;
 import org.contextmapper.dsl.contextMappingDSL.SculptorModule;
 import org.contextmapper.dsl.contextMappingDSL.Subdomain;
 import org.contextmapper.dsl.contextMappingDSL.UserRequirement;
@@ -190,6 +192,18 @@ public class UniquenessValidator extends AbstractCMLValidator {
 			}));
 			if (IteratorExtensions.size(duplicateFlows) > 1)
 				error(String.format(FLOW_NAME_NOT_UNIQUE, flow.getName()), flow, ContextMappingDSLPackage.Literals.FLOW__NAME);
+		}
+	}
+	
+	@Check
+	public void validateThatFunctionalityNameIsUnique(final Functionality functionality) {
+		if (functionality != null) {
+			Iterator<Functionality> allFunctionalities = EcoreUtil2.eAllOfType(getRootCMLModel(functionality), Functionality.class).iterator();
+			Iterator<Functionality> duplicateFunctionalities = IteratorExtensions.filter(allFunctionalities, ((Function1<Functionality, Boolean>) (Functionality f) -> {
+				return f.getName().equals(functionality.getName());
+			}));
+			if (IteratorExtensions.size(duplicateFunctionalities) > 1)
+				error(String.format(FUNCTIONALITY_NAME_NOT_UNIQUE, functionality.getName()), functionality, ContextMappingDSLPackage.Literals.FUNCTIONALITY__NAME);
 		}
 	}
 	

--- a/org.contextmapper.dsl/src/org/contextmapper/dsl/validation/ValidationMessages.java
+++ b/org.contextmapper.dsl/src/org/contextmapper/dsl/validation/ValidationMessages.java
@@ -33,6 +33,10 @@ public class ValidationMessages {
 	public static final String ORGANIZATIONAL_MAP_DOES_NOT_CONTAIN_TEAM = "Your Context Map is of the type ORGANIZATIONAL but does not contain Bounded Contexts of the type TEAM. This type of Context Map is intended to model team relationships.";
 	public static final String COMMAND_OR_OPERATION_IS_NOT_PART_OF_BOUNDED_CONTEXT = "The command or operation '%s' is not part of the '%s' Bounded Context. Please ensure that your workflow only uses commands, operations and events that are part of the same Bounded Context.";
 	public static final String STATE_VALUE_DOES_NOT_BELONG_TO_AGGREGATE = "'%s' is not a state of the Aggregate '%s'.";
+	public static final String FUNCTIONALITY_STEP_CONTEXT_NOT_ON_MAP = "The Bounded Context '%s' is not part of the Context Map.";
+	public static final String FUNCTIONALITY_STEP_SERVICE_NOT_ON_STEP_CONTEXT = "The Service '%s' is not part of the Bounded Context '%s'.";
+	public static final String FUNCTIONALITY_STEP_OPERATION_NOT_ON_STEP_SERVICE = "The operation '%s' is not part of the Service '%s'.";
+	public static final String FUNCTIONALITY_STEP_SERVICE_NOT_APPLICATION_SERVICE = "The Service '%s' is not an Application service.";
 
 	/* Uniqueness problems */
 	public static final String BOUNDED_CONTEXT_NAME_NOT_UNIQUE = "Multiple bounded contexts with the name '%s' have been declared.";
@@ -46,6 +50,7 @@ public class ValidationMessages {
 	public static final String SERVICE_NAME_NOT_UNIQUE_IN_BC = "Multiple services with the name '%s' have been declared in this Bounded Context.";
 	public static final String SERVICE_NAME_NOT_UNIQUE_IN_SUBDOMAIN = "Multiple services with the name '%s' have been declared in this Subdomain.";
 	public static final String FLOW_NAME_NOT_UNIQUE = "Multiple flows with the name '%s' have been declared. Please provide unique names!";
+	public static final String FUNCTIONALITY_NAME_NOT_UNIQUE = "Multiple functionalities with the name '%s' have been declared. Please provide unique names!";
 
 	/* Generator problems */
 	public static final String EMPTY_UML_COMPONENT_DIAGRAM_MESSAGE = "Sorry, we cannot generate a component diagram. Your Context Map seems to be empty.";


### PR DESCRIPTION
Add initial syntax to represent functionalities, including sagas.

Example of new syntax:
```
ContextMap myMap {
    contains Context1
    contains Context2
}

BoundedContext Context1 {
    Application {
        Functionality aSaga {
            sagaOrchestrator

            Context1.Service1.step1
            Context2.Service2.step2
        }

        Service Service1 {
            step1;
        }
    }
}

BoundedContext Context2 {
    Application {
        Service Service2 {
            step2;
        }
    }
}
```